### PR TITLE
fix: rename wal-g-exporter for mysql metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,28 +76,28 @@ walg_wal_archive_missing_count 0.0
 
 ## Exposed Metrics for MySQL
 ```
-# HELP walg_mysql_basebackup Remote MySQL basebackups
-# TYPE walg_mysql_basebackup gauge
-walg_mysql_basebackup{backup_name="stream_20250909T173557Z",compressed_size="2542957",finish_time="2025-09-09T17:36:04.995146Z",start_time="2025-09-09T17:35:57.973341Z",uncompressed_size="74101916"} 1.757439364995146e+09
-walg_mysql_basebackup{backup_name="stream_20250909T173746Z",compressed_size="2542840",finish_time="2025-09-09T17:37:55.645579Z",start_time="2025-09-09T17:37:46.636711Z",uncompressed_size="74101915"} 1.757439475645579e+09
-# HELP walg_mysql_basebackup_count Number of basebackups
-# TYPE walg_mysql_basebackup_count gauge
-walg_mysql_basebackup_count 2.0
-# HELP walg_mysql_basebackup_exception 1 if basebackup retrieval failed else 0
-# TYPE walg_mysql_basebackup_exception gauge
-walg_mysql_basebackup_exception 0.0
-# HELP walg_mysql_oldest_basebackup Oldest basebackup start time (unix seconds)
-# TYPE walg_mysql_oldest_basebackup gauge
-walg_mysql_oldest_basebackup 1.757439357973341e+09
-# HELP walg_mysql_last_backup_duration Duration seconds of last basebackup
-# TYPE walg_mysql_last_backup_duration gauge
-walg_mysql_last_backup_duration 9.008868
-# HELP walg_mysql_latest_active_binlog Current active binlog file
-# TYPE walg_mysql_latest_active_binlog gauge
-walg_mysql_latest_active_binlog{file="mysql-bin.000003"} 1.0
-walg_mysql_latest_active_binlog{file="mysql-bin.000004"} 1.0
-# HELP walg_mysql_latest_uploaded_binlog Latest uploaded binlog file (wal-g storage)
-# TYPE walg_mysql_latest_uploaded_binlog gauge
-walg_mysql_latest_uploaded_binlog{file="mysql-bin.000002"} 1.0
-walg_mysql_latest_uploaded_binlog{file="mysql-bin.000003"} 1.0
+# HELP walg_basebackup Remote MySQL basebackups
+# TYPE walg_basebackup gauge
+walg_basebackup{backup_name="stream_20250909T173557Z",compressed_size="2542957",finish_time="2025-09-09T17:36:04.995146Z",start_time="2025-09-09T17:35:57.973341Z",uncompressed_size="74101916"} 1.757439364995146e+09
+walg_basebackup{backup_name="stream_20250909T173746Z",compressed_size="2542840",finish_time="2025-09-09T17:37:55.645579Z",start_time="2025-09-09T17:37:46.636711Z",uncompressed_size="74101915"} 1.757439475645579e+09
+# HELP walg_basebackup_count Number of basebackups
+# TYPE walg_basebackup_count gauge
+walg_basebackup_count 2.0
+# HELP walg_basebackup_exception 1 if basebackup retrieval failed else 0
+# TYPE walg_basebackup_exception gauge
+walg_basebackup_exception 0.0
+# HELP walg_oldest_basebackup Oldest basebackup start time (unix seconds)
+# TYPE walg_oldest_basebackup gauge
+walg_oldest_basebackup 1.757439357973341e+09
+# HELP walg_last_backup_duration Duration seconds of last basebackup
+# TYPE walg_last_backup_duration gauge
+walg_last_backup_duration 9.008868
+# HELP walg_latest_active_binlog Current active binlog file
+# TYPE walg_latest_active_binlog gauge
+walg_latest_active_binlog{file="mysql-bin.000003"} 1.0
+walg_latest_active_binlog{file="mysql-bin.000004"} 1.0
+# HELP walg_latest_uploaded_binlog Latest uploaded binlog file (wal-g storage)
+# TYPE walg_latest_uploaded_binlog gauge
+walg_latest_uploaded_binlog{file="mysql-bin.000002"} 1.0
+walg_latest_uploaded_binlog{file="mysql-bin.000003"} 1.0
 ```

--- a/mysql/Makefile.mysql
+++ b/mysql/Makefile.mysql
@@ -29,7 +29,7 @@ mysql-exporter-restart:
 	docker compose -f $(MYSQL_COMPOSE) restart mysql-walg-exporter
 
 mysql-metrics:
-	curl -s http://localhost:19352/metrics | grep -E 'walg_mysql'
+	curl -s http://localhost:19352/metrics | grep -E 'walg'
 
 mysql-test: mysql-reset mysql-up
 	@echo "Basebackup count:"; curl -s http://localhost:19352/metrics | grep walg || true
@@ -37,7 +37,7 @@ mysql-test: mysql-reset mysql-up
 
 # Full test including seeding data and creating an initial backup
 mysql-test-full: mysql-reset mysql-up mysql-init mysql-backup mysql-exporter-restart mysql-binlog-push 
-	@echo "Post-backup metrics snapshot:"; curl -s http://localhost:19352/metrics | grep -E 'walg_mysql_(basebackup_count|last_backup_duration|binlog_files_present)' || true
+	@echo "Post-backup metrics snapshot:"; curl -s http://localhost:19352/metrics | grep -E 'walg_(basebackup_count|last_backup_duration|binlog_files_present)' || true
 
 mysql-init:
 	# Wait for MySQL TCP readiness then create sample DB, table, data, and grant remote root

--- a/mysql/mysql_exporter.py
+++ b/mysql/mysql_exporter.py
@@ -108,14 +108,14 @@ class MySQLExporter:
         self.latest_active_binlog = None
 
         # Metrics
-        self.basebackup = Gauge('walg_mysql_basebackup', 'Remote MySQL basebackups',
+        self.basebackup = Gauge('walg_basebackup', 'Remote basebackups',
                                 ['backup_name', 'uncompressed_size', 'compressed_size', 'start_time', 'finish_time'])
-        self.basebackup_count = Gauge('walg_mysql_basebackup_count', 'Number of basebackups')
-        self.basebackup_exception_flag = Gauge('walg_mysql_basebackup_exception', '1 if basebackup retrieval failed else 0')
-        self.oldest_basebackup = Gauge('walg_mysql_oldest_basebackup', 'Oldest basebackup start time (unix seconds)')
-        self.last_backup_duration = Gauge('walg_mysql_last_backup_duration', 'Duration seconds of last basebackup')
-        self.latest_active_binlog_gauge = Gauge('walg_mysql_latest_active_binlog', 'Current active binlog file', ['file'])
-        self.latest_uploaded_binlog_gauge = Gauge('walg_mysql_latest_uploaded_binlog', 'Latest uploaded binlog file (wal-g storage)', ['file'])
+        self.basebackup_count = Gauge('walg_basebackup_count', 'Number of basebackups')
+        self.basebackup_exception_flag = Gauge('walg_basebackup_exception', '1 if basebackup retrieval failed else 0')
+        self.oldest_basebackup = Gauge('walg_oldest_basebackup', 'Oldest basebackup start time (unix seconds)')
+        self.last_backup_duration = Gauge('walg_last_backup_duration', 'Duration seconds of last basebackup')
+        self.latest_active_binlog_gauge = Gauge('walg_binlog_latest_active', 'Current active binlog file', ['file'])
+        self.latest_uploaded_binlog_gauge = Gauge('walg_binlog_latest_uploaded', 'Latest uploaded binlog file (wal-g storage)', ['file'])
 
         self.basebackup_count.set_function(lambda: len(self.bbs))
         self.oldest_basebackup.set_function(self._oldest_bb_callback)


### PR DESCRIPTION
Update mysql metric name to 
```
walg_basebackup
walg_basebackup_count
walg_basebackup_exception
walg_oldest_basebackup
walg_last_backup_duration
walg_binlog_latest_active
walg_latest_uploaded_binlog
```